### PR TITLE
fix: build errors on ROS 2 Jazzy

### DIFF
--- a/graph_based_slam/src/graph_based_slam.cpp
+++ b/graph_based_slam/src/graph_based_slam.cpp
@@ -69,7 +69,7 @@ GraphBasedSLAM::GraphBasedSLAM(const rclcpp::NodeOptions & node_options)
   prior_noise_ = gtsam::noiseModel::Diagonal::Variances(Vector6);
 
   const double rate = declare_parameter<double>("rate");
-  timer_ = create_timer(
+  timer_ = rclcpp::create_timer(
     this, get_clock(), rclcpp::Rate(rate).period(),
     std::bind(&GraphBasedSLAM::optimization_callback, this));
 }

--- a/lidar_scan_matcher/CMakeLists.txt
+++ b/lidar_scan_matcher/CMakeLists.txt
@@ -10,11 +10,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic )
 endif()
 
+find_package(GTSAM REQUIRED)
 find_package(PCL REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-include_directories(include ${PCL_INCLUDE_DIRS})
+include_directories(include ${PCL_INCLUDE_DIRS} ${GTSAM_INCLUDE_DIR})
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}.cpp
@@ -25,7 +26,7 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE ${PROJECT_NAME}_node
 )
 
-target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} gtsam)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/lidar_scan_matcher/include/lidar_scan_matcher/lidar_scan_matcher.hpp
+++ b/lidar_scan_matcher/include/lidar_scan_matcher/lidar_scan_matcher.hpp
@@ -50,7 +50,7 @@
 #include <tf2/transform_datatypes.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
-#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 using PointType = pcl::PointXYZI;
 

--- a/lidar_scan_matcher/package.xml
+++ b/lidar_scan_matcher/package.xml
@@ -21,6 +21,7 @@
   <depend>visualization_msgs</depend>
   <depend>ndt_omp</depend>
   <depend>fast_gicp</depend>
+  <depend>gtsam</depend>
   <depend>lidar_graph_slam_utils</depend>
   <depend>lidar_graph_slam_msgs</depend>
 


### PR DESCRIPTION
## 概要
ROS 2 Jazzy 環境で `colcon build` が通るように、ビルドエラーを修正します。
（`lidar_graph_slam_utils` の GTSAM リンク修正は #14 で対応済みのため、本PRはその下流パッケージ分です）

## 変更内容

### `lidar_scan_matcher`
- **GTSAM の明示リンク** — `find_package(GTSAM REQUIRED)` と `target_link_libraries(... gtsam)`、`include_directories` に `${GTSAM_INCLUDE_DIR}` を追加。公開ヘッダー `lidar_graph_slam_utils.hpp` が `gtsam` 型を露出しており、それを include する本パッケージにも GTSAM のインクルードパスが必要なため。`package.xml` にも `<depend>gtsam</depend>` を追加。
- **`tf2_sensor_msgs` ヘッダー** — `tf2_sensor_msgs/tf2_sensor_msgs.h` → `.hpp`。Jazzy で `.h` シムが削除されたため。

### `graph_based_slam`
- **`create_timer` の名前空間修飾** — `create_timer(...)` を `rclcpp::create_timer(...)` に修正。無修飾だと `Node` のメンバ関数（Jazzy でシグネチャ変更）に解決されてビルドエラーになるため、4引数のフリー関数に明示的に解決させる。

## 動作確認
`lidar_graph_slam` 配下の全パッケージ（`lidar_graph_slam_utils` / `lidar_scan_matcher` / `graph_based_slam` / `lidar_graph_slam` / `lidar_graph_slam_msgs` / `points_prefiltering`）で `colcon build` 成功を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)