### PR TITLE
fix: improve loop-closure pose-graph quality and add debug visualization

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam.hpp
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam.hpp
@@ -33,6 +33,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/path.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/geometry/Rot3.h>
@@ -100,6 +101,7 @@ private:
   rclcpp::Publisher<lidar_graph_slam_msgs::msg::KeyFrameArray>::SharedPtr
     modified_key_frame_publisher_;
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr candidate_key_frame_publisher_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr accepted_loop_publisher_;
 
   rclcpp::TimerBase::SharedPtr timer_;
 
@@ -117,6 +119,7 @@ private:
   std::shared_ptr<gtsam::ISAM2> optimizer_;
   gtsam::Values initial_estimate_;
   gtsam::noiseModel::Diagonal::shared_ptr prior_noise_;
+  gtsam::noiseModel::Diagonal::shared_ptr odometry_noise_;
 
   pcl::PointCloud<PointType>::Ptr key_frame_point_;
   lidar_graph_slam_msgs::msg::KeyFrameArray key_frame_array_;
@@ -138,6 +141,9 @@ private:
   double accumulate_distance_threshold_;
 
   nav_msgs::msg::Path candidate_line_;
+
+  // accumulated LINE_LIST marker of accepted (added to the graph) loop-closure edges
+  visualization_msgs::msg::Marker accepted_loop_marker_;
 };
 
 #endif

--- a/graph_based_slam/src/graph_based_slam.cpp
+++ b/graph_based_slam/src/graph_based_slam.cpp
@@ -40,6 +40,8 @@ GraphBasedSLAM::GraphBasedSLAM(const rclcpp::NodeOptions & node_options)
   modified_path_publisher_ = this->create_publisher<nav_msgs::msg::Path>("modified_path", 5);
   candidate_key_frame_publisher_ =
     this->create_publisher<nav_msgs::msg::Path>("candidate_key_frame", 5);
+  accepted_loop_publisher_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
+    "accepted_loop_edges", rclcpp::QoS{1}.transient_local());
   modified_key_frame_publisher_ =
     this->create_publisher<lidar_graph_slam_msgs::msg::KeyFrameArray>("modified_key_frame", 5);
   modified_map_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
@@ -65,9 +67,32 @@ GraphBasedSLAM::GraphBasedSLAM(const rclcpp::NodeOptions & node_options)
     this->declare_parameter<std::string>("registration_method");
   registration_ = get_registration(registration_method);
 
-  gtsam::Vector Vector6(6);
-  Vector6 << 1e-6, 1e-6, 1e-6, 1e-8, 1e-8, 1e-6;
-  prior_noise_ = gtsam::noiseModel::Diagonal::Variances(Vector6);
+  // NOTE: gtsam::Pose3 tangent ordering is [rx, ry, rz, x, y, z] (rotation first).
+  // Prior: tightly anchor the first key frame to fix the gauge freedom.
+  gtsam::Vector prior_variance(6);
+  prior_variance << 1e-6, 1e-6, 1e-6, 1e-8, 1e-8, 1e-8;
+  prior_noise_ = gtsam::noiseModel::Diagonal::Variances(prior_variance);
+
+  // Odometry: scan-matching relative motion is good but NOT rigid. Using a moderate
+  // covariance (rot ~0.6deg, trans ~5cm) lets loop-closure constraints redistribute the
+  // accumulated drift. (Previously this reused the ultra-tight prior noise, which made the
+  // odometry chain effectively rigid and caused loop closures to be ignored.)
+  gtsam::Vector odometry_variance(6);
+  odometry_variance << 1e-4, 1e-4, 1e-4, 2.5e-3, 2.5e-3, 2.5e-3;
+  odometry_noise_ = gtsam::noiseModel::Diagonal::Variances(odometry_variance);
+
+  // cyan LINE_LIST marker accumulating every accepted loop-closure edge for RViz debugging.
+  // (cyan keeps it distinct from the green modified_path trajectory.)
+  accepted_loop_marker_.header.frame_id = "map";
+  accepted_loop_marker_.ns = "accepted_loop_edges";
+  accepted_loop_marker_.id = 0;
+  accepted_loop_marker_.type = visualization_msgs::msg::Marker::LINE_LIST;
+  accepted_loop_marker_.action = visualization_msgs::msg::Marker::ADD;
+  accepted_loop_marker_.scale.x = 0.3;
+  accepted_loop_marker_.color.g = 1.0;
+  accepted_loop_marker_.color.b = 1.0;
+  accepted_loop_marker_.color.a = 1.0;
+  accepted_loop_marker_.pose.orientation.w = 1.0;
 
   const double rate = declare_parameter<double>("rate");
   timer_ = rclcpp::create_timer(
@@ -239,6 +264,11 @@ void GraphBasedSLAM::optimization_callback()
 
   if (key_frame_array_.keyframes.empty()) return;
 
+  // Skip new loop detection until the previous closure has been applied by adjust_pose (on the
+  // next key frame). Otherwise the timer keeps re-detecting the same candidate on still-drifted
+  // poses and adds duplicate loop factors, over-constraining that location.
+  if (is_loop_closed_) return;
+
   const int key_frame_size = key_frame_array_.keyframes.size();
   const auto latest_key_frame = key_frame_array_.keyframes.back();
   pcl::PointCloud<PointType>::Ptr nearest_key_frame_cloud(new pcl::PointCloud<PointType>);
@@ -320,26 +350,42 @@ void GraphBasedSLAM::optimization_callback()
   const double fitness_score = registration_->getFitnessScore();
   const bool has_converged = registration_->hasConverged();
 
-  RCLCPP_INFO_STREAM(get_logger(), "fitness score: " << fitness_score);
-  RCLCPP_INFO_STREAM(get_logger(), "min_id: " << min_id);
   candidate_key_frame_publisher_->publish(candidate_line_);
 
-  if (!has_converged or score_threshold_ < fitness_score) return;
+  if (!has_converged or score_threshold_ < fitness_score) {
+    RCLCPP_INFO(
+      get_logger(), "loop candidate REJECTED (latest=%d, min_id=%d): converged=%d, fitness=%.4f (> %.4f)",
+      key_frame_size - 1, min_id, has_converged, fitness_score, score_threshold_);
+    return;
+  }
+  RCLCPP_INFO(
+    get_logger(), "loop candidate ACCEPTED (latest=%d, min_id=%d): fitness=%.4f",
+    key_frame_size - 1, min_id, fitness_score);
 
   // correct position
   auto pose_from = geometry_pose_to_gtsam_pose(
     convert_matrix_to_pose(transform * geometry_pose_to_matrix(latest_key_frame.pose)));
   // candidate position
   auto pose_to = geometry_pose_to_gtsam_pose(key_frame_array_.keyframes[min_id].pose);
-  gtsam::Vector Vector6(6);
-  Vector6 << fitness_score, fitness_score, fitness_score, fitness_score, fitness_score,
-    fitness_score;
+  // Loop-closure noise scaled by the registration fitness score, with rotation and
+  // translation treated separately and clamped to sane floors. Order: [rx, ry, rz, x, y, z].
+  const double loop_translation_variance = std::max(1e-2, fitness_score);
+  const double loop_rotation_variance = std::max(1e-3, fitness_score * 0.1);
+  gtsam::Vector loop_variance(6);
+  loop_variance << loop_rotation_variance, loop_rotation_variance, loop_rotation_variance,
+    loop_translation_variance, loop_translation_variance, loop_translation_variance;
   gtsam::noiseModel::Diagonal::shared_ptr optimize_noise =
-    gtsam::noiseModel::Diagonal::Variances(Vector6);
+    gtsam::noiseModel::Diagonal::Variances(loop_variance);
   graph_.add(gtsam::BetweenFactor<gtsam::Pose3>(
     key_frame_size - 1, min_id, pose_from.between(pose_to), optimize_noise));
 
-  RCLCPP_INFO_STREAM(get_logger(), "optimized...");
+  // visualize the accepted loop edge (latest key frame <-> matched candidate) in cyan.
+  accepted_loop_marker_.points.emplace_back(latest_key_frame.pose.position);
+  accepted_loop_marker_.points.emplace_back(key_frame_array_.keyframes[min_id].pose.position);
+  accepted_loop_marker_.header.stamp = now();
+  visualization_msgs::msg::MarkerArray accepted_loop_markers;
+  accepted_loop_markers.markers.emplace_back(accepted_loop_marker_);
+  accepted_loop_publisher_->publish(accepted_loop_markers);
 
   // update
   optimizer_->update(graph_);
@@ -356,17 +402,21 @@ void GraphBasedSLAM::key_frame_callback(const lidar_graph_slam_msgs::msg::KeyFra
   if (!is_initialized_key_frame_) is_initialized_key_frame_ = true;
 
   auto key_frame_size = key_frame_array_.keyframes.size();
-  auto latest_key_frame = geometry_pose_to_gtsam_pose(msg->pose);
+  // Raw scan-matcher global pose of the current key frame.
+  auto current_raw_pose = geometry_pose_to_gtsam_pose(msg->pose);
   if (key_frame_array_.keyframes.empty()) {
-    gtsam::Vector Vector6(6);
-    graph_.add(gtsam::PriorFactor<gtsam::Pose3>(0, latest_key_frame, prior_noise_));
-    initial_estimate_.insert(0, latest_key_frame);
+    graph_.add(gtsam::PriorFactor<gtsam::Pose3>(0, current_raw_pose, prior_noise_));
+    initial_estimate_.insert(0, current_raw_pose);
   } else {
-    auto previous_key_frame = geometry_pose_to_gtsam_pose(key_frame_array_.keyframes.back().pose);
+    // Odometry edge measurement must be the relative motion between consecutive RAW
+    // scan-matcher poses. Using the optimized previous pose (key_frame_array_) would fold the
+    // loop-closure correction back into the measurement and corrupt the graph after a closure.
+    auto previous_raw_pose =
+      geometry_pose_to_gtsam_pose(key_frame_raw_array_.keyframes.back().pose);
     graph_.add(gtsam::BetweenFactor<gtsam::Pose3>(
-      key_frame_size - 1, key_frame_size, previous_key_frame.between(latest_key_frame),
-      prior_noise_));
-    initial_estimate_.insert(key_frame_size, latest_key_frame);
+      key_frame_size - 1, key_frame_size, previous_raw_pose.between(current_raw_pose),
+      odometry_noise_));
+    initial_estimate_.insert(key_frame_size, current_raw_pose);
   }
 
   optimizer_->update(graph_, initial_estimate_);
@@ -421,11 +471,21 @@ pcl::PointCloud<PointType>::Ptr GraphBasedSLAM::transform_point_cloud(
 void GraphBasedSLAM::adjust_pose()
 {
   auto current_estimate = optimizer_->calculateEstimate();
-  auto estimated_pose = current_estimate.at<gtsam::Pose3>(current_estimate.size() - 1);
+
+  double max_shift = 0.0;
+  double sum_shift = 0.0;
 
   for (std::size_t idx = 0; idx < current_estimate.size(); idx++) {
-    key_frame_array_.keyframes[idx].pose =
-      gtsam_pose_to_geometry_pose(current_estimate.at<gtsam::Pose3>(idx));
+    const auto & previous_position = key_frame_array_.keyframes[idx].pose.position;
+    const gtsam::Pose3 optimized = current_estimate.at<gtsam::Pose3>(idx);
+
+    const double shift = std::hypot(
+      optimized.x() - previous_position.x, optimized.y() - previous_position.y,
+      optimized.z() - previous_position.z);
+    max_shift = std::max(max_shift, shift);
+    sum_shift += shift;
+
+    key_frame_array_.keyframes[idx].pose = gtsam_pose_to_geometry_pose(optimized);
 
     PointType key_frame_point;
     key_frame_point.x = key_frame_array_.keyframes[idx].pose.position.x;
@@ -433,6 +493,13 @@ void GraphBasedSLAM::adjust_pose()
     key_frame_point.z = key_frame_array_.keyframes[idx].pose.position.z;
     key_frame_point_->points[idx] = key_frame_point;
   }
+
+  const double mean_shift = current_estimate.empty()
+                              ? 0.0
+                              : sum_shift / static_cast<double>(current_estimate.size());
+  RCLCPP_INFO(
+    get_logger(), "loop closure correction: max=%.3f m, mean=%.3f m over %zu key frames", max_shift,
+    mean_shift, current_estimate.size());
 }
 
 void GraphBasedSLAM::update_estimate_path()

--- a/lidar_graph_slam/rviz/rviz.config
+++ b/lidar_graph_slam/rviz/rviz.config
@@ -224,6 +224,18 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /nearest_key_frame_marker
       Value: false
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: accepted_loop_edges
+      Namespaces:
+        {}
+      Topic:
+        Depth: 1
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /accepted_loop_edges
+      Value: true
     - Alpha: 0.10000000149011612
       Buffer Length: 1
       Class: rviz_default_plugins/Path

--- a/lidar_scan_matcher/src/lidar_scan_matcher.cpp
+++ b/lidar_scan_matcher/src/lidar_scan_matcher.cpp
@@ -144,7 +144,10 @@ void LidarScanMatcher::callback_cloud(const sensor_msgs::msg::PointCloud2::Share
     key_frame.id = id_;
     id_++;
 
-    pcl::toROSMsg(*input_cloud_ptr, key_frame.cloud);
+    // Store the cloud in the base frame, consistent with subsequent key frames below.
+    // (Previously the first key frame stored the raw sensor-frame cloud, offsetting it by the
+    // base->sensor extrinsic when the map was reconstructed.)
+    pcl::toROSMsg(*base_to_sensor_cloud, key_frame.cloud);
     key_frame_array_.keyframes.emplace_back(key_frame);
 
     *target_cloud_ += *base_to_sensor_cloud;


### PR DESCRIPTION
ループ閉合の効果が出ない（ループ検知しても地図が補正されない）問題を、ポーズグラフのノイズモデル設計を中心に修正します。あわせてループ閉合の挙動を確認するためのデバッグ可視化を追加します。

## ループ閉合ロジックの修正 (L)

### L1: オドメトリ拘束とループ拘束のノイズモデルを分離（主因）
- オドメトリのBetweenFactorが**超タイトな `prior_noise_`(variance≈1e-6) を流用**しており、オドメトリ鎖が剛体扱いになって**ループ拘束がほぼ無視**され、地図が補正されなかった。
- オドメトリ用 `odometry_noise_` を新設（回転σ≈0.6°/並進σ≈5cm）。ループ拘束はfitness scoreでスケールしつつ回転/並進を分離＋下限クランプ。
- GTSAM `Pose3` の接空間順序 `[rx, ry, rz, x, y, z]` をコメント明記。`prior_noise_` のz成分も整合。

### L2: オドメトリ相対拘束をraw pose差分で構築
- 未使用だった `key_frame_raw_array_`（生スキャンマッチャpose）を活用し、**連続する生pose同士の差分**を計測値に。従来は「最適化後の前pose × 生の現pose」で、ループ補正のジャンプが以降のオドメトリ計測へ混入していた。

### L3: 初回キーフレーム点群の座標系統一
- 初回KFのみ生センサ座標系で保存され、地図再構成時に base→sensor 外部パラメータ分ずれていた問題を修正（base座標系に統一）。

## ロバスト性
- ループ採用後 `adjust_pose` で反映されるまで**新規ループ検出をスキップ**（`if (is_loop_closed_) return;`）。タイマー駆動が補正前のドリフトposeで同一候補を再検出し、**重複factorで局所を過剰拘束**するのを防止。

## デバッグ可視化
- ループ候補の **ACCEPTED/REJECTED** とfitness、`adjust_pose` での**補正量(max/mean)** をログ出力。低ドリフトでも「ループが採用され最適化が動いている」ことを定量確認可能。
- 採用ループエッジを **`/accepted_loop_edges`（シアンLINE_LIST）** でpublishし、RViz設定に表示を追加。候補(白 `/candidate_key_frame`)と採用(シアン)を見分け可能。

## 動作確認
- ROS 2 Jazzy で `colcon build` 成功
- デモbagで、最適化後経路(`/modified_path`)が道路構造に沿って補正されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)