### PR TITLE
feat: save map via an action with progress feedback and down-sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 ## 2. run
 ```bash
-ros2 launch lidar_graph_slam lidar_graph_slam.launch.xml
+ros2 launch lidar_graph_slam lidar_graph_slam.launch.py
 ```
 ## 3. save map
+The map is saved via an action. `resolution` is the voxel leaf size [m] used to
+down-sample the dense map before saving (set `0.0` to save the dense map as-is).
 ```bash
-ros2 service call /save_map lidar_graph_slam_msgs/srv/SaveMap "{resolution: 0.2, path: "<MAP PATH>"}"
-
+ros2 action send_goal /save_map lidar_graph_slam_msgs/action/SaveMap "{resolution: 0.2, path: <MAP PATH>}"
 ```
 
 ## ToDo

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam.hpp
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam.hpp
@@ -26,10 +26,11 @@
 #include <fast_gicp/gicp/fast_gicp.hpp>
 #include <lidar_graph_slam_utils/lidar_graph_slam_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 
+#include "lidar_graph_slam_msgs/action/save_map.hpp"
 #include "lidar_graph_slam_msgs/msg/key_frame.hpp"
 #include "lidar_graph_slam_msgs/msg/key_frame_array.hpp"
-#include "lidar_graph_slam_msgs/srv/save_map.hpp"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/path.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -45,6 +46,7 @@
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/PriorFactor.h>
 #include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -59,6 +61,9 @@ using PointType = pcl::PointXYZI;
 class GraphBasedSLAM : public rclcpp::Node
 {
 public:
+  using SaveMap = lidar_graph_slam_msgs::action::SaveMap;
+  using GoalHandleSaveMap = rclcpp_action::ServerGoalHandle<SaveMap>;
+
   GraphBasedSLAM(const rclcpp::NodeOptions & node_options);
   ~GraphBasedSLAM() = default;
 
@@ -89,9 +94,12 @@ public:
   pcl::Registration<PointType, PointType>::Ptr get_registration(
     const std::string & registration_method);
 
-  bool save_map_service(
-    const lidar_graph_slam_msgs::srv::SaveMap::Request::SharedPtr req,
-    lidar_graph_slam_msgs::srv::SaveMap::Response::SharedPtr res);
+  rclcpp_action::GoalResponse handle_save_map_goal(
+    const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const SaveMap::Goal> goal);
+  rclcpp_action::CancelResponse handle_save_map_cancel(
+    const std::shared_ptr<GoalHandleSaveMap> goal_handle);
+  void handle_save_map_accepted(const std::shared_ptr<GoalHandleSaveMap> goal_handle);
+  void execute_save_map(const std::shared_ptr<GoalHandleSaveMap> goal_handle);
 
 private:
   rclcpp::Subscription<lidar_graph_slam_msgs::msg::KeyFrame>::SharedPtr key_frame_subscriber_;
@@ -108,7 +116,7 @@ private:
   // under a multi-threaded executor (e.g. the composed component_container_mt).
   rclcpp::CallbackGroup::SharedPtr optimization_callback_group_;
 
-  rclcpp::Service<lidar_graph_slam_msgs::srv::SaveMap>::SharedPtr save_map_service_;
+  rclcpp_action::Server<SaveMap>::SharedPtr save_map_action_server_;
 
   // registration
   pcl::Registration<PointType, PointType>::Ptr registration_;

--- a/graph_based_slam/package.xml
+++ b/graph_based_slam/package.xml
@@ -9,6 +9,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/graph_based_slam/src/graph_based_slam.cpp
+++ b/graph_based_slam/src/graph_based_slam.cpp
@@ -22,6 +22,8 @@
 
 #include "graph_based_slam/graph_based_slam.hpp"
 
+#include <thread>
+
 using namespace lidar_graph_slam_utils;
 
 namespace
@@ -56,10 +58,11 @@ GraphBasedSLAM::GraphBasedSLAM(const rclcpp::NodeOptions & node_options)
   modified_map_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
     "modified_map", rclcpp::QoS{1}.transient_local());
 
-  save_map_service_ = this->create_service<lidar_graph_slam_msgs::srv::SaveMap>(
-    "save_map",
-    std::bind(
-      &GraphBasedSLAM::save_map_service, this, std::placeholders::_1, std::placeholders::_2));
+  save_map_action_server_ = rclcpp_action::create_server<SaveMap>(
+    this, "save_map",
+    std::bind(&GraphBasedSLAM::handle_save_map_goal, this, std::placeholders::_1, std::placeholders::_2),
+    std::bind(&GraphBasedSLAM::handle_save_map_cancel, this, std::placeholders::_1),
+    std::bind(&GraphBasedSLAM::handle_save_map_accepted, this, std::placeholders::_1));
 
   kd_tree_.reset(new pcl::KdTreeFLANN<PointType>());
   key_frame_point_.reset(new pcl::PointCloud<PointType>);
@@ -570,46 +573,94 @@ void GraphBasedSLAM::publish_map()
   modified_map_publisher_->publish(map_msg);
 }
 
-bool GraphBasedSLAM::save_map_service(
-  const lidar_graph_slam_msgs::srv::SaveMap::Request::SharedPtr req,
-  lidar_graph_slam_msgs::srv::SaveMap::Response::SharedPtr res)
+rclcpp_action::GoalResponse GraphBasedSLAM::handle_save_map_goal(
+  const rclcpp_action::GoalUUID & /*uuid*/, std::shared_ptr<const SaveMap::Goal> goal)
 {
-  // Snapshot the key frames under the lock, then build the map from the copy without holding it
-  // (the service runs in a different callback group than the SLAM callbacks under a MT executor).
+  RCLCPP_INFO(
+    get_logger(), "save_map goal received: path=%s resolution=%.3f", goal->path.c_str(),
+    goal->resolution);
+  return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+}
+
+rclcpp_action::CancelResponse GraphBasedSLAM::handle_save_map_cancel(
+  const std::shared_ptr<GoalHandleSaveMap> /*goal_handle*/)
+{
+  RCLCPP_INFO(get_logger(), "save_map goal canceled");
+  return rclcpp_action::CancelResponse::ACCEPT;
+}
+
+void GraphBasedSLAM::handle_save_map_accepted(const std::shared_ptr<GoalHandleSaveMap> goal_handle)
+{
+  // Run the (potentially long) map build + save on its own thread so the executor is not blocked.
+  std::thread{std::bind(&GraphBasedSLAM::execute_save_map, this, std::placeholders::_1), goal_handle}
+    .detach();
+}
+
+void GraphBasedSLAM::execute_save_map(const std::shared_ptr<GoalHandleSaveMap> goal_handle)
+{
+  const auto goal = goal_handle->get_goal();
+  auto feedback = std::make_shared<SaveMap::Feedback>();
+  auto result = std::make_shared<SaveMap::Result>();
+
+  // Snapshot the key frames under the lock, then build the dense map from the copy without holding
+  // it (this action runs in its own thread, concurrently with the SLAM callbacks).
   lidar_graph_slam_msgs::msg::KeyFrameArray key_frames;
   {
     std::lock_guard<std::mutex> lock(graph_mutex_);
     key_frames = key_frame_array_;
   }
 
-  pcl::PointCloud<PointType>::Ptr map(new pcl::PointCloud<PointType>);
-  for (std::size_t idx = 0; idx < key_frames.keyframes.size(); idx++) {
+  const std::size_t total = key_frames.keyframes.size();
+  if (total == 0) {
+    result->success = false;
+    result->message = "no key frames to save";
+    goal_handle->abort(result);
+    return;
+  }
+
+  // Build the dense (full-resolution) map.
+  pcl::PointCloud<PointType>::Ptr dense_map(new pcl::PointCloud<PointType>);
+  for (std::size_t idx = 0; idx < total; idx++) {
+    if (goal_handle->is_canceling()) {
+      result->success = false;
+      result->message = "canceled";
+      goal_handle->canceled(result);
+      return;
+    }
+
     pcl::PointCloud<PointType>::Ptr key_frame_cloud(new pcl::PointCloud<PointType>);
     pcl::fromROSMsg(key_frames.keyframes[idx].cloud, *key_frame_cloud);
-
-    pcl::PointCloud<PointType>::Ptr transformed_cloud(new pcl::PointCloud<PointType>);
     const Eigen::Matrix4f matrix = geometry_pose_to_matrix(key_frames.keyframes[idx].pose);
-    transformed_cloud = transform_point_cloud(key_frame_cloud, matrix);
+    *dense_map += *transform_point_cloud(key_frame_cloud, matrix);
 
-    *map += *transformed_cloud;
+    feedback->progress = static_cast<float>(idx + 1) / static_cast<float>(total);
+    goal_handle->publish_feedback(feedback);
   }
 
+  // Down-sample the dense map before saving (resolution <= 0 saves the dense map as-is).
   pcl::PointCloud<PointType>::Ptr map_cloud(new pcl::PointCloud<PointType>);
-
-  if (req->resolution <= 0.0) {
-    map_cloud = map;
+  if (goal->resolution <= 0.0f) {
+    map_cloud = dense_map;
   } else {
     pcl::VoxelGrid<PointType> voxel_grid_filter;
-    voxel_grid_filter.setLeafSize(req->resolution, req->resolution, req->resolution);
-    voxel_grid_filter.setInputCloud(map);
+    voxel_grid_filter.setLeafSize(goal->resolution, goal->resolution, goal->resolution);
+    voxel_grid_filter.setInputCloud(dense_map);
     voxel_grid_filter.filter(*map_cloud);
   }
-
   map_cloud->header.frame_id = "map";
-  int ret = pcl::io::savePCDFile(req->path, *map_cloud);
-  res->ret = (ret == 0);
 
-  return true;
+  const int ret = pcl::io::savePCDFileBinary(goal->path, *map_cloud);
+  result->success = (ret == 0);
+  if (result->success) {
+    result->message =
+      "saved " + std::to_string(map_cloud->size()) + " points to " + goal->path;
+    RCLCPP_INFO(get_logger(), "%s", result->message.c_str());
+    goal_handle->succeed(result);
+  } else {
+    result->message = "failed to write PCD to " + goal->path;
+    RCLCPP_ERROR(get_logger(), "%s", result->message.c_str());
+    goal_handle->abort(result);
+  }
 }
 
 #include "rclcpp_components/register_node_macro.hpp"

--- a/lidar_graph_slam_msgs/CMakeLists.txt
+++ b/lidar_graph_slam_msgs/CMakeLists.txt
@@ -16,8 +16,8 @@ ament_auto_find_build_dependencies()
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/KeyFrame.msg"
   "msg/KeyFrameArray.msg"
-  "srv/SaveMap.srv"
-  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs sensor_msgs
+  "action/SaveMap.action"
+  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs sensor_msgs action_msgs
 )
 
 if(BUILD_TESTING)

--- a/lidar_graph_slam_msgs/action/SaveMap.action
+++ b/lidar_graph_slam_msgs/action/SaveMap.action
@@ -1,0 +1,10 @@
+# Goal: where to save and the down-sampling leaf size (<= 0 saves the dense map as-is).
+float32 resolution
+string path
+---
+# Result
+bool success
+string message
+---
+# Feedback: fraction of key frames accumulated into the map so far (0.0 - 1.0).
+float32 progress

--- a/lidar_graph_slam_msgs/package.xml
+++ b/lidar_graph_slam_msgs/package.xml
@@ -14,6 +14,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>action_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/lidar_graph_slam_msgs/srv/SaveMap.srv
+++ b/lidar_graph_slam_msgs/srv/SaveMap.srv
@@ -1,4 +1,0 @@
-float32 resolution
-string path
----
-bool ret


### PR DESCRIPTION
地図保存をサービスから**アクション**に変更し、保存時に**密マップをダウンサンプリング**して書き出します。

## 変更内容

### feat(save_map): service → action
- `lidar_graph_slam_msgs`: `srv/SaveMap.srv` を **`action/SaveMap.action`** に置き換え。
  - Goal: `resolution`, `path`
  - Result: `success`, `message`
  - Feedback: `progress`（0.0–1.0、地図構築の進捗）
- `graph_based_slam`: アクションサーバ化。
  - **専用ワーカースレッド**で実行し、executorをブロックしない。
  - **キーフレーム単位の進捗feedback**とキャンセルに対応。
  - **密（全解像度）マップを構築 → goalの`resolution`でダウンサンプル**（`<=0`なら密のまま）→ **バイナリPCD**で保存。

### docs
- 実行コマンドを `lidar_graph_slam.launch.py` に更新（PR #20でPython化済み）。
- 保存方法を action 呼び出しに更新:
  ```bash
  ros2 action send_goal /save_map lidar_graph_slam_msgs/action/SaveMap "{resolution: 0.2, path: <MAP PATH>}"
  ```

## 動作確認
- ROS 2 Jazzy で `colcon build` 成功（msgsのaction生成 + graph_based_slamのアクションサーバ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)